### PR TITLE
Move hook_update changes to hook_schema.

### DIFF
--- a/meta_link/meta_link.install
+++ b/meta_link/meta_link.install
@@ -39,32 +39,13 @@ function meta_link_schema() {
   			'not null' => TRUE,
   			'default'=> 0,
   		),
+      'is_rejected' => array(
+        'type' => 'int',
+        'description' => "Rejected item flag",
+        'length' => 1,
+      ),
   	),
   	'primary key' => array('id'),
   );
   return $schema;
-}
-
-/**
- * Implements hook_update_N().
- *
- * Adds a table for storing matcher data.
- */
-function meta_link_update_7001() {
-	$schema = module_invoke('meta_link', 'schema');
-  $table_name = 'meta_link_data';
-  db_create_table($table_name, $schema[$table_name]);
-}
-
-
-/**
- * Adds Rejected Flag field to meta_link_data table.
- */
-function meta_link_update_7002() {
-  $spec = array(
-    'type' => 'int',
-    'description' => "Send Email Flag",
-    'length' => 1,
-  );
-  db_add_field( 'meta_link_data', 'is_rejected', $spec);
 }


### PR DESCRIPTION
`meta_data_link.is_rejected` was only in a hook_update, so it wasn't getting created for new installs. This moves it to `hook_schema` and removes the `hook_update` code because we can only care about clean installs at this point. 
